### PR TITLE
Support HMR

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,17 +2,42 @@ module.exports = SingleModuleInstancePlugin;
 
 function SingleModuleInstancePlugin() {}
 
+
+/*
+  Sanitize string strips away the injected webpack header and footer stanzas that
+  are subject to change.
+
+  It does this by first checking for react hot loader in the header,
+  and then the footer. If HMR is found in both, then it grabs the inner
+  module text.
+
+ */
+function sanitizeString(text) {
+   var length = text.length;
+   if (length < 400) return text;
+   var firstReactHotLoader = text.substr(0,200).indexOf("REACT HOT LOADER");
+   if (firstReactHotLoader == -1) return text;
+
+   var lastReactHotLoader = text.substr(length - 800, 100).lastIndexOf("REACT HOT LOADER");
+   if (lastReactHotLoader == -1) return text;
+   lastReactHotLoader += length - 800;
+
+   var firstNewLine = text.indexOf("\n", firstReactHotLoader);
+   return text.substr(firstNewLine, lastReactHotLoader - firstNewLine);
+}
+
 SingleModuleInstancePlugin.prototype.apply = function(compiler) {
   compiler.plugin('compilation', function(compilation) {
     compilation.mainTemplate.plugin('require', function(originalSource) {
       return this.asString([
         '// SingleModuleInstancePlugin',
+        `${sanitizeString}`,
         'if (!installedModules[moduleId]) {',
         this.indent([
           'var source = String(modules[moduleId]);',
           'for (var id in modules) {',
           this.indent([
-            'if (id !== moduleId && installedModules[id] && String(modules[id]) === source) {',
+            'if (id !== moduleId && installedModules[id] && sanitizeString(String(modules[id])) === sanitizeString(source)) {',
             this.indent([
               'installedModules[moduleId] = installedModules[id];',
               'break;'

--- a/index.js
+++ b/index.js
@@ -13,17 +13,16 @@ function SingleModuleInstancePlugin() {}
 
  */
 function sanitizeString(text) {
-   var length = text.length;
-   if (length < 400) return text;
-   var firstReactHotLoader = text.substr(0,200).indexOf("REACT HOT LOADER");
-   if (firstReactHotLoader == -1) return text;
-
-   var lastReactHotLoader = text.substr(length - 800, 100).lastIndexOf("REACT HOT LOADER");
-   if (lastReactHotLoader == -1) return text;
-   lastReactHotLoader += length - 800;
-
-   var firstNewLine = text.indexOf("\n", firstReactHotLoader);
-   return text.substr(firstNewLine, lastReactHotLoader - firstNewLine);
+  /*
+   * Sanitize the source by ignoring webpack require calls:
+   * Say modules 1 & 2 are duplicates of module A
+   *     modules 3 & 4 are duplicates of module B
+   * If module A uses require("B")
+   *    module 1 might contain __webpack_require__(3)
+   *    module 2 might contain __webpack_require__(4)
+   * Stripping the module ids from webpack_require allows to dedupe module 1 and 2.
+   */
+   return text.replace(/__webpack_require__\(\d+\)/g,"");
 }
 
 function getModuleBody(id) {


### PR DESCRIPTION
This PR fixes a problem we see when Hot Module Reloading is running and some modules have different versions of react and therefore different injected header / footer stanzas.


#### One header version
```
/* WEBPACK VAR INJECTION */(function(module) {/* REACT HOT LOADER */ if (true) { (function () { var ReactHotAPI = __webpack_require__(190), RootInstanceProvider = __webpack_require__(198),        ReactMount = __webpack_require__(13), React = __webpack_require__(65); module.makeHot = module.hot.data ? module.hot.data.makeHot : ReactHotAPI(function () { return RootInstanceProvider.getRoot       Instances(ReactMount); }, React); })(); } try { (function () {
```

#### Another header version
```
/* WEBPACK VAR INJECTION */(function(module) {/* REACT HOT LOADER */ if (true) { (function () { var ReactHotAPI = __webpack_require__(3), RootInstanceProvider = __webpack_require__(11), Rea       ctMount = __webpack_require__(387), React = __webpack_require__(439); module.makeHot = module.hot.data ? module.hot.data.makeHot : ReactHotAPI(function () { return RootInstanceProvider.getRootI       nstances(ReactMount); }, React); })(); } try { (function () {
```

This fixes that problem by first sanitizing the modules.

##### Does this scale?

The sanitization is super verbose so that it is really fast. In our [app](github.com/devtools-html/debugger.html) webpack bootstrap went from 800ms to 1,300ms which is not that bad considering the extra work we do.


